### PR TITLE
Fix Authorization Problem

### DIFF
--- a/services/question/src/routes/routes.ts
+++ b/services/question/src/routes/routes.ts
@@ -1,112 +1,123 @@
-import { Question, QuestionDoc, questionDocSchema } from "@common/shared-types";
-import { NextFunction, Request, Response, Router } from 'express';
-import { StatusCodes } from "http-status-codes";
-import { SafeParseReturnType } from "zod";
-import * as controller from '../controller/controller';
-import { DuplicateQuestionError } from "../utils/errors";
-import { requireAdmin, requireLogin } from "./auth";
+import { Question, QuestionDoc, questionDocSchema } from '@common/shared-types'
+import { NextFunction, Request, Response, Router } from 'express'
+import { StatusCodes } from 'http-status-codes'
+import * as controller from '../controller/controller'
+import { DuplicateQuestionError } from '../utils/errors'
+import { requireAdmin, requireLogin } from './auth'
 
 // Provides the parsed QuestionDoc to subsequent middleware
 function parseQuestionDoc(req: Request, res: Response, next: NextFunction) {
   // Attempt to parse data
-  let rawQuestionDoc: unknown = req.body.questionDoc;
-  let result: SafeParseReturnType<QuestionDoc, QuestionDoc> =
-    questionDocSchema.safeParse(rawQuestionDoc);
+  let rawQuestionDoc: unknown = req.body
+  let result = questionDocSchema
+    .partial()
+    .refine(
+      (val) => Object.keys(val).map((key) => val[key as keyof typeof val] !== undefined),
+      {
+        message: 'Please provide at least one field',
+      }
+    )
+    .safeParse(rawQuestionDoc)
 
   if (!result.success) {
-    res.status(StatusCodes.BAD_REQUEST);
-    res.json({ error: result.error });
-    return;
+    res.status(StatusCodes.BAD_REQUEST)
+    res.json({ error: result.error })
+    return
   }
 
-  res.locals.questionDoc = result.data;
-  next();
+  res.locals.questionDoc = result.data
+  next()
 }
 
 function genericServerError(res: Response, e: unknown) {
-  res.status(StatusCodes.INTERNAL_SERVER_ERROR);
-  res.json({ error: e});
+  res.status(StatusCodes.INTERNAL_SERVER_ERROR)
+  res.json({ error: e })
 }
 
-let router: Router = Router();
-export default router;
+let router: Router = Router()
+export default router
 
 // All routes require login
-router.use(requireLogin);
+router.use(requireLogin)
 
 // GET all questions
 router.get('/', async (req: Request, res: Response) => {
-  let { complexity, categories } = req.body;
+  let { complexity, categories } = req.body
 
-  let questions: Question[] = await controller.getAll(complexity, categories);
+  let questions: Question[] = await controller.getAll(complexity, categories)
 
-  res.status(StatusCodes.OK);
-  res.json(questions);
-});
+  res.status(StatusCodes.OK)
+  res.json(questions)
+})
 
 // GET question with specified ID
 router.get('/:id', async (req: Request, res: Response) => {
-  let id = req.params.id;
+  let id = req.params.id
 
-  let question: Question | null = await controller.get(id);
+  let question: Question | null = await controller.get(id)
 
   if (question === null) {
-    res.status(StatusCodes.NOT_FOUND);
-    res.send();
-    return;
+    res.status(StatusCodes.NOT_FOUND)
+    res.send()
+    return
   }
 
-  res.status(StatusCodes.OK);
-  res.json(question);
-});
+  res.status(StatusCodes.OK)
+  res.json(question)
+})
 
 // Create new specified question
 router.post('/', requireAdmin, parseQuestionDoc, async (req: Request, res: Response) => {
-  let questionDoc: QuestionDoc = res.locals.questionDoc;
+  let questionDoc: QuestionDoc = res.locals.questionDoc
 
   try {
-    let question: Question = await controller.add(questionDoc);
+    let question: Question = await controller.add(questionDoc)
 
-    res.status(StatusCodes.CREATED);
-    res.json(question);
+    res.status(StatusCodes.CREATED)
+    res.json(question)
   } catch (e) {
     if (e instanceof DuplicateQuestionError) {
-      res.status(StatusCodes.CONFLICT);
-      res.json(e.duplicateQuestion);
-      return;
+      res.status(StatusCodes.CONFLICT)
+      res.json(e.duplicateQuestion)
+      return
     }
 
-    genericServerError(res, e);
+    genericServerError(res, e)
   }
-});
+})
 
 // Overwrite specified question
-router.put('/:id', requireAdmin, parseQuestionDoc, async (req: Request, res: Response) => {
-  let id = req.params.id;
-  let questionDoc: QuestionDoc = res.locals.questionDoc;
+router.put(
+  '/:id',
+  requireAdmin,
+  parseQuestionDoc,
+  async (req: Request, res: Response) => {
+    let id = req.params.id
+    let questionDoc: QuestionDoc = res.locals.questionDoc
 
-  try {
-    let question: Question = await controller.set(id, questionDoc);
+    try {
+      let question: Question = await controller.set(id, questionDoc)
 
-    res.status(StatusCodes.OK);
-    res.json(question);
-  } catch (e) {
-    if (e instanceof DuplicateQuestionError) {
-      res.status(StatusCodes.CONFLICT);
-      res.json(e.duplicateQuestion);
-      return;
+      res.status(StatusCodes.OK)
+      res.json(question)
+    } catch (e) {
+      if (e instanceof DuplicateQuestionError) {
+        res.status(StatusCodes.CONFLICT)
+        res.json(e.duplicateQuestion)
+        return
+      }
+
+      genericServerError(res, e)
     }
-
-    genericServerError(res, e);
   }
-});
+)
 
 // DELETE specified question
 router.delete('/:id', requireAdmin, async (req: Request, res: Response) => {
-  let id = req.params.id;
+  let id = req.params.id
 
-  await controller.destroy(id);
+  await controller.destroy(id)
 
-  res.status(StatusCodes.NO_CONTENT);
-  res.send();
-});
+  res.status(StatusCodes.NO_CONTENT)
+  res.send()
+})

--- a/services/user/src/controller/auth-controller.ts
+++ b/services/user/src/controller/auth-controller.ts
@@ -8,15 +8,15 @@ import { Request, Response } from 'express'
 import { db } from '../db/clients'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
-import { User, loginRequestSchema, VerifyRequest } from '../model'
+import { User, loginFormSchema, ExtractedUser } from '../model'
 
-interface UserRequest extends Request {
-  user?: User
+interface VerifyRequest extends Request {
+  user?: ExtractedUser
 }
 
 export async function handleLogin(req: Request, res: Response) {
   try {
-    const parsedRequest = loginRequestSchema.safeParse(req.body)
+    const parsedRequest = loginFormSchema.safeParse(req.body)
     if (!parsedRequest.success) {
       return res.status(400).json({ message: 'Email and/or password are missing' })
     }

--- a/services/user/src/controller/auth-controller.ts
+++ b/services/user/src/controller/auth-controller.ts
@@ -23,6 +23,7 @@ export async function handleLogin(req: Request, res: Response) {
     const { data } = parsedRequest
 
     const userSnapshot = await db.where('email', '==', data.email).get()
+
     if (!userSnapshot) {
       return res.status(401).json({ message: 'Wrong email and/or password' })
     }

--- a/services/user/src/controller/user-controller.ts
+++ b/services/user/src/controller/user-controller.ts
@@ -2,7 +2,7 @@ import bcrypt from 'bcrypt'
 import { Request, Response } from 'express'
 import { Query } from 'firebase-admin/firestore'
 import { db } from '../db/clients'
-import { User, userRequestSchema, isAdminSchema } from '../model'
+import { User, registerFormRequestSchema, isAdminSchema } from '../model'
 
 export async function getAllUsers(req: Request, res: Response): Promise<Response> {
   try {
@@ -44,7 +44,7 @@ export async function getUser(req: Request, res: Response): Promise<Response> {
 
 export async function createUser(req: Request, res: Response): Promise<Response> {
   try {
-    const parsedRequest = userRequestSchema.safeParse(req.body)
+    const parsedRequest = registerFormRequestSchema.safeParse(req.body)
     if (!parsedRequest.success) {
       return res
         .status(400)
@@ -84,7 +84,7 @@ export async function createUser(req: Request, res: Response): Promise<Response>
 
 export async function updateUser(req: Request, res: Response): Promise<Response> {
   try {
-    const parsedRequest = userRequestSchema
+    const parsedRequest = registerFormRequestSchema
       .partial()
       .refine(
         (val) =>

--- a/services/user/src/middleware/basic-access-control.ts
+++ b/services/user/src/middleware/basic-access-control.ts
@@ -8,6 +8,7 @@ import { Response, NextFunction } from 'express'
 import jwt, { JwtPayload } from 'jsonwebtoken'
 import { db } from '../db/clients'
 import { User, VerifyRequest } from '../model'
+import { auth } from 'firebase-admin'
 
 export function verifyAccessToken(
   req: VerifyRequest,

--- a/services/user/src/middleware/basic-access-control.ts
+++ b/services/user/src/middleware/basic-access-control.ts
@@ -4,10 +4,14 @@ if (process.env.NODE_ENV) {
 } else {
   dotenv.config({ path: '.env' })
 }
-import { Response, NextFunction } from 'express'
+import { Response, Request, NextFunction } from 'express'
 import jwt, { JwtPayload } from 'jsonwebtoken'
 import { db } from '../db/clients'
-import { User, VerifyRequest } from '../model'
+import { User, ExtractedUser } from '../model'
+
+interface VerifyRequest extends Request {
+  user?: ExtractedUser
+}
 
 export function verifyAccessToken(
   req: VerifyRequest,

--- a/services/user/src/model.ts
+++ b/services/user/src/model.ts
@@ -1,39 +1,4 @@
 import z from 'zod'
-import { Request } from 'express'
-
-export const loginRequestSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1),
-})
-
-export type LoginRequest = z.infer<typeof loginRequestSchema>
-
-export const userRequestSchema = z.object({
-  username: z.string().min(1),
-  email: z.string().email(),
-  password: z.string().min(1),
-})
-
-export type UserRequest = z.infer<typeof userRequestSchema>
-
-export const extractedUserSchema = z.object({
-  id: z.string().min(1),
-  username: z.string().min(1),
-  email: z.string().email(),
-  isAdmin: z.boolean(),
-})
-
-export type ExtractedUser = z.infer<typeof extractedUserSchema>
-
-export interface VerifyRequest extends Request {
-  user?: ExtractedUser
-}
-
-export const isAdminSchema = z.object({
-  isAdmin: z.boolean(),
-})
-
-export type IsAdminRequest = z.infer<typeof isAdminSchema>
 
 export const userSchema = z.object({
   username: z.string().min(1),
@@ -43,4 +8,43 @@ export const userSchema = z.object({
   createdAt: z.date(),
 })
 
+export const sensitiveUserSchema = userSchema.extend({
+  password: z.string().min(1),
+})
+
+export const loginFormSchema = sensitiveUserSchema.pick({
+  email: true,
+  password: true,
+})
+
+export const registerFormSchema = sensitiveUserSchema.pick({
+  username: true,
+  email: true,
+  password: true,
+})
+
+export const extractedUserSchema = userSchema
+  .pick({
+    username: true,
+    email: true,
+    isAdmin: true,
+  })
+  .extend({
+    id: z.string().min(1),
+  })
+
+export const updatePrivilegeSchema = userSchema.pick({
+  isAdmin: true,
+})
+
 export type User = z.infer<typeof userSchema>
+
+export type SensitiveUser = z.infer<typeof sensitiveUserSchema>
+
+export type LoginForm = z.infer<typeof loginFormSchema>
+
+export type registerForm = z.infer<typeof registerFormSchema>
+
+export type ExtractedUser = z.infer<typeof extractedUserSchema>
+
+export type UpdatePrivilegeRequest = z.infer<typeof updatePrivilegeSchema>

--- a/services/user/src/scripts/create-admin.ts
+++ b/services/user/src/scripts/create-admin.ts
@@ -9,7 +9,6 @@ import bcrypt from 'bcrypt'
 
 const createAdminUser = async () => {
   const salt = bcrypt.genSaltSync(10)
-  console.log(process.env.ADMIN_PASSWORD)
   const hashedPassword = bcrypt.hashSync(process.env.ADMIN_PASSWORD!, salt)
 
   const adminUser = {


### PR DESCRIPTION
Previously frontend is not able to call get questions due to its authorization token not properly passed to the question service. Change the question service such that it takes token from the header instead of the request body. 
Additionally, change update question to allow partial input.
Then change the return type of `verifyUser` to `ExtractedUser` since it has an additionally `id` filed compared to `User`.
Schemas should ideally be placed in common folder after this is done.