### PR TITLE
Refactor schema with SensitiveUserSchema

### DIFF
--- a/services/user/src/controller/auth-controller.ts
+++ b/services/user/src/controller/auth-controller.ts
@@ -8,7 +8,7 @@ import { Request, Response } from 'express'
 import { db } from '../db/clients'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
-import { User, loginFormSchema, ExtractedUser } from '../model'
+import { SensitiveUser, loginFormSchema, ExtractedUser } from '../model'
 
 interface VerifyRequest extends Request {
   user?: ExtractedUser
@@ -29,7 +29,7 @@ export async function handleLogin(req: Request, res: Response) {
     }
 
     const userDoc = userSnapshot.docs[0]
-    const userData = userDoc.data() as User
+    const userData = userDoc.data() as SensitiveUser
 
     const match = await bcrypt.compare(data.password, userData.password)
     if (!match) {

--- a/services/user/src/controller/user-controller.ts
+++ b/services/user/src/controller/user-controller.ts
@@ -2,15 +2,14 @@ import bcrypt from 'bcrypt'
 import { Request, Response } from 'express'
 import { Query } from 'firebase-admin/firestore'
 import { db } from '../db/clients'
-import { User, registerFormRequestSchema, isAdminSchema } from '../model'
+import { User, SensitiveUser, registerFormSchema, updatePrivilegeSchema } from '../model'
 
 export async function getAllUsers(req: Request, res: Response): Promise<Response> {
   try {
     const usersSnapshot = await db.get()
     const users = usersSnapshot.docs.map((doc) => {
       const userData = doc.data() as User
-      const { password, ...userResponse } = userData
-      return { id: doc.id, ...userResponse }
+      return { id: doc.id, ...userData }
     })
 
     return res.status(200).json({ message: `Found users`, data: users })
@@ -29,11 +28,10 @@ export async function getUser(req: Request, res: Response): Promise<Response> {
       return res.status(404).json({ message: `User ${userId} not found` })
     } else {
       const userData = userDoc.data() as User
-      const { password, ...userResponse } = userData
 
       return res.status(200).json({
         message: `Found user`,
-        data: { id: userDoc.id, ...userResponse },
+        data: { id: userDoc.id, ...userData },
       })
     }
   } catch (err) {
@@ -44,7 +42,7 @@ export async function getUser(req: Request, res: Response): Promise<Response> {
 
 export async function createUser(req: Request, res: Response): Promise<Response> {
   try {
-    const parsedRequest = registerFormRequestSchema.safeParse(req.body)
+    const parsedRequest = registerFormSchema.safeParse(req.body)
     if (!parsedRequest.success) {
       return res
         .status(400)
@@ -60,7 +58,7 @@ export async function createUser(req: Request, res: Response): Promise<Response>
     const salt = bcrypt.genSaltSync(10)
     const hashedPassword = bcrypt.hashSync(data.password, salt)
 
-    const createdUser: User = {
+    const createdUser: SensitiveUser = {
       username: data.username,
       email: data.email,
       password: hashedPassword,
@@ -84,7 +82,7 @@ export async function createUser(req: Request, res: Response): Promise<Response>
 
 export async function updateUser(req: Request, res: Response): Promise<Response> {
   try {
-    const parsedRequest = registerFormRequestSchema
+    const parsedRequest = registerFormSchema
       .partial()
       .refine(
         (val) =>
@@ -108,7 +106,7 @@ export async function updateUser(req: Request, res: Response): Promise<Response>
       return res.status(404).json({ message: `User ${userId} not found` })
     }
 
-    const userData = userDoc.data() as User
+    const userData = userDoc.data() as SensitiveUser
     if (data.username || data.email) {
       const existingUser = await findUserByUsernameOrEmail(data.username, data.email)
       if (existingUser && existingUser.id !== userId) {
@@ -130,11 +128,10 @@ export async function updateUser(req: Request, res: Response): Promise<Response>
 
     const updatedUserDoc = await db.doc(userId).get()
     const updatedUserData = updatedUserDoc.data() as User
-    const { password: _, ...updatedUserResponse } = updatedUserData
 
     return res.status(200).json({
       message: `Updated data for user ${userId}`,
-      data: { id: updatedUserDoc.id, ...updatedUserResponse },
+      data: { id: updatedUserDoc.id, ...updatedUserData },
     })
   } catch (err) {
     console.error(err)
@@ -147,7 +144,7 @@ export async function updateUserPrivilege(
   res: Response
 ): Promise<Response> {
   try {
-    const parsedRequest = isAdminSchema.safeParse(req.body)
+    const parsedRequest = updatePrivilegeSchema.safeParse(req.body)
     if (!parsedRequest.success) {
       return res.status(400).json({ message: 'isAdmin is missing!' })
     }
@@ -164,11 +161,10 @@ export async function updateUserPrivilege(
 
     const updatedUserDoc = await db.doc(userId).get()
     const updatedUserData = updatedUserDoc.data() as User
-    const { password, ...updatedUserResponse } = updatedUserData
 
     return res.status(200).json({
       message: `Updated privilege for user ${userId}`,
-      data: { id: userDoc.id, ...updatedUserResponse },
+      data: { id: userDoc.id, ...updatedUserData },
     })
   } catch (err) {
     console.error(err)

--- a/services/user/src/model.ts
+++ b/services/user/src/model.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 export const userSchema = z.object({
   username: z.string().min(1),
   email: z.string().email(),
-  password: z.string().min(1),
   isAdmin: z.boolean(),
   createdAt: z.date(),
 })


### PR DESCRIPTION
Change the implementation of the user service to so that it uses the same schema as the `common/shared-types`.
However, currently there is problem when trying to directly use schema from `common/shared-types`, thus we temporarily use local schema instead.