### PR TITLE
Implement Question Display and Exit Room Ui

### DIFF
--- a/frontend/src/components/Collaboration/CodingEditor.tsx
+++ b/frontend/src/components/Collaboration/CodingEditor.tsx
@@ -98,7 +98,7 @@ export default function CodingEditor({ roomId, isOpen }: Props) {
       ref={elementRef}
       style={{
         height: "100%",
-        width: "50vw",
+        width: "100%",
         border: "1px solid #000",
         margin: "0 auto",
       }}

--- a/frontend/src/components/Questions/QuestionsTable.tsx
+++ b/frontend/src/components/Questions/QuestionsTable.tsx
@@ -26,7 +26,7 @@ const COMPLEXITY_COLOR_MAP: Record<Question["complexity"], string> = {
   Hard: "red",
 };
 
-function stringToHexColor(str: string) {
+export function stringToHexColor(str: string) {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
     hash = str.charCodeAt(i) + ((hash << 5) - hash);

--- a/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
+++ b/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
@@ -38,6 +38,12 @@ export function Collaboration() {
   const queryClient = useQueryClient();
   queryClient.removeQueries();
 
+  const exitRoom = () => {
+    navigate({
+      to: "/matching",
+    });
+  };
+
   const {
     data: userRoomData,
     isLoading,
@@ -107,7 +113,7 @@ export function Collaboration() {
           </Grid.Col>
 
           <Grid.Col span={{ base: 12, xs: 4 }}>
-            <Stack h="80vh">
+            <Stack h="80vh" justify="space-between">
               <Paper w="auto" shadow="md" p="lg" h="75vh" withBorder>
                 <Stack gap={10}>
                   <Title c="black" order={3}>
@@ -128,7 +134,8 @@ export function Collaboration() {
                   <Text c="black">{userRoomData.question.description}</Text>
                 </Stack>
               </Paper>
-              <Button color="black" w="10vw">
+
+              <Button color="black" w="10vw" onClick={exitRoom}>
                 Exit Room
               </Button>
             </Stack>

--- a/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
+++ b/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
@@ -1,4 +1,15 @@
-import { Paper, Stack, Text, Title } from "@mantine/core";
+import {
+  Paper,
+  Stack,
+  Text,
+  Title,
+  Grid,
+  Avatar,
+  Badge,
+  Group,
+  Button,
+} from "@mantine/core";
+import { IconX, IconLoader } from "@tabler/icons-react";
 import {
   createFileRoute,
   useRouterState,
@@ -10,6 +21,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "../../api";
 import { notifications } from "@mantine/notifications";
 import { AxiosError } from "axios";
+import { stringToHexColor } from "../../components/Questions/QuestionsTable";
 
 export const Route = createFileRoute("/_authenticated/collaboration/$roomId")({
   component: Collaboration,
@@ -70,17 +82,69 @@ export function Collaboration() {
   });
 
   return (
-    <Paper shadow="md" p="lg" h="90vh" withBorder>
-      <Title ta="center">Collaboration</Title>
-      <Stack h="90%">
-        {isLoading ? (
-          <Text>"Loading..."</Text>
-        ) : isSuccess ? (
-          <CodingEditor isOpen={userRoomData.isOpen} roomId={roomId} />
-        ) : null}
+    <Stack align="center">
+      <Group justify="space-between" w="100%">
+        <Title ta="center">Collaboration</Title>
+        <Button variant="light" color="red">
+          Exit Room
+        </Button>
+      </Group>
+      {isLoading ? (
+        <Paper shadow="md" withBorder p="lg">
+          <Stack align="center">
+            <Avatar color="blue">
+              <IconLoader />
+            </Avatar>
+            <Text c="black" fw="bold">
+              Loading...
+            </Text>
+          </Stack>
+        </Paper>
+      ) : isSuccess ? (
+        <Grid w="100%">
+          <Grid.Col span={{ base: 12, xs: 4 }}>
+            <Paper w="auto" shadow="md" p="lg" h="80vh" withBorder>
+              <Stack gap={10}>
+                <Title c="black" order={3}>
+                  {userRoomData.question.title}
+                </Title>
+                <Group gap={2} align="flex-start">
+                  {userRoomData.question.categories.map((category) => (
+                    <Badge
+                      key={category}
+                      size="sm"
+                      autoContrast
+                      bg={stringToHexColor(category)}
+                    >
+                      {category}
+                    </Badge>
+                  ))}
+                </Group>
+                <Text c="black">{userRoomData.question.description}</Text>
+              </Stack>
+            </Paper>
+          </Grid.Col>
 
-        {isError ? <Text c="red">"Error fetching room"</Text> : null}
-      </Stack>
-    </Paper>
+          <Grid.Col span={{ base: 12, xs: 8 }}>
+            <Paper shadow="md" p="lg" h="80vh" withBorder>
+              <CodingEditor isOpen={userRoomData.isOpen} roomId={roomId} />
+            </Paper>
+          </Grid.Col>
+        </Grid>
+      ) : null}
+
+      {isError ? (
+        <Paper shadow="md" withBorder p="lg">
+          <Stack align="center">
+            <Avatar color="red">
+              <IconX />
+            </Avatar>
+            <Text c="black" fw="bold">
+              Error fetching room
+            </Text>
+          </Stack>
+        </Paper>
+      ) : null}
+    </Stack>
   );
 }

--- a/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
+++ b/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
@@ -83,12 +83,7 @@ export function Collaboration() {
 
   return (
     <Stack align="center">
-      <Group justify="space-between" w="100%">
-        <Title ta="center">Collaboration</Title>
-        <Button variant="light" color="red">
-          Exit Room
-        </Button>
-      </Group>
+      <Title ta="center">Collaboration</Title>
       {isLoading ? (
         <Paper shadow="md" withBorder p="lg">
           <Stack align="center">
@@ -102,33 +97,38 @@ export function Collaboration() {
         </Paper>
       ) : isSuccess ? (
         <Grid w="100%">
-          <Grid.Col span={{ base: 12, xs: 4 }}>
-            <Paper w="auto" shadow="md" p="lg" h="80vh" withBorder>
-              <Stack gap={10}>
-                <Title c="black" order={3}>
-                  {userRoomData.question.title}
-                </Title>
-                <Group gap={2} align="flex-start">
-                  {userRoomData.question.categories.map((category) => (
-                    <Badge
-                      key={category}
-                      size="sm"
-                      autoContrast
-                      bg={stringToHexColor(category)}
-                    >
-                      {category}
-                    </Badge>
-                  ))}
-                </Group>
-                <Text c="black">{userRoomData.question.description}</Text>
-              </Stack>
-            </Paper>
-          </Grid.Col>
-
           <Grid.Col span={{ base: 12, xs: 8 }}>
             <Paper shadow="md" p="lg" h="80vh" withBorder>
               <CodingEditor isOpen={userRoomData.isOpen} roomId={roomId} />
             </Paper>
+          </Grid.Col>
+
+          <Grid.Col span={{ base: 12, xs: 4 }}>
+            <Stack h="80vh">
+              <Paper w="auto" shadow="md" p="lg" h="75vh" withBorder>
+                <Stack gap={10}>
+                  <Title c="black" order={3}>
+                    {userRoomData.question.title}
+                  </Title>
+                  <Group gap={2} align="flex-start">
+                    {userRoomData.question.categories.map((category) => (
+                      <Badge
+                        key={category}
+                        size="sm"
+                        autoContrast
+                        bg={stringToHexColor(category)}
+                      >
+                        {category}
+                      </Badge>
+                    ))}
+                  </Group>
+                  <Text c="black">{userRoomData.question.description}</Text>
+                </Stack>
+              </Paper>
+              <Button color="black" w="10vw">
+                Exit Room
+              </Button>
+            </Stack>
           </Grid.Col>
         </Grid>
       ) : null}

--- a/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
+++ b/frontend/src/routes/_authenticated/collaboration.$roomId.tsx
@@ -17,7 +17,7 @@ import {
 } from "@tanstack/react-router";
 import CodingEditor from "../../components/Collaboration/CodingEditor";
 import { UserRoomCreatedData } from "@common/shared-types";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../api";
 import { notifications } from "@mantine/notifications";
 import { AxiosError } from "axios";
@@ -34,6 +34,9 @@ export function Collaboration() {
   });
   const { roomId } = Route.useParams();
   const navigate = useNavigate();
+
+  const queryClient = useQueryClient();
+  queryClient.removeQueries();
 
   const {
     data: userRoomData,
@@ -110,7 +113,7 @@ export function Collaboration() {
                   <Title c="black" order={3}>
                     {userRoomData.question.title}
                   </Title>
-                  <Group gap={2} align="flex-start">
+                  <Group gap={5} align="flex-start">
                     {userRoomData.question.categories.map((category) => (
                       <Badge
                         key={category}
@@ -131,9 +134,7 @@ export function Collaboration() {
             </Stack>
           </Grid.Col>
         </Grid>
-      ) : null}
-
-      {isError ? (
+      ) : isError ? (
         <Paper shadow="md" withBorder p="lg">
           <Stack align="center">
             <Avatar color="red">


### PR DESCRIPTION
Added Question and Exit Room Ui to the Collaboration Page.

Exit room is done by directly navigating to `/matching` as disconnection from the `HocuspocusServer` is already handled by the cleanup function of `useEffect` in `CodeEditor`.

Modified loading and error ui for the Collaboration Page.

Closes #83 